### PR TITLE
[MONDRIAN-2110] Distinct Count support in MonetDB

### DIFF
--- a/src/main/mondrian/spi/impl/MonetDbDialect.java
+++ b/src/main/mondrian/spi/impl/MonetDbDialect.java
@@ -46,33 +46,38 @@ public class MonetDbDialect extends JdbcDialectImpl {
     }
 
     @Override
-    public boolean allowsMultipleDistinctSqlMeasures() {
-        return false;
-    }
-
-    @Override
-    public boolean allowsCountDistinct() {
-        return false;
-    }
-
-    @Override
     public boolean requiresAliasForFromQuery() {
         return true;
     }
 
     @Override
-    public boolean allowsCompoundCountDistinct() {
+    public boolean allowsSelectNotInGroupBy() {
         return false;
     }
 
     @Override
-    public boolean supportsGroupByExpressions() {
-        return false;
+    public boolean allowsJoinOn() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresGroupByAlias() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresOrderByAlias() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresHavingAlias() {
+        return true;
     }
 
     @Override
     public void quoteStringLiteral(StringBuilder buf, String s) {
-        // Go beyond Util.singleQuoteString; also quote backslash, like MySQL.
+        // Go beyond Util.singleQuoteString; also quote backslash.
         buf.append('\'');
         String s0 = Util.replace(s, "'", "''");
         String s1 = Util.replace(s0, "\\", "\\\\");


### PR DESCRIPTION
MonetDB supports distinct-count, while the current dialect file doesn't.
There is a Jira issue on this here: http://jira.pentaho.com/browse/MONDRIAN-2110 
This is the latest patch posted to the issue, and it worked perfectly for me.
After discussing with @magicaltrout on this issue on IRC, he suggested I made it a pull request.
