### PR TITLE
[MONDRIAN-2468] MemberFormatter not applied using member.getCaption

### DIFF
--- a/src/main/java/mondrian/rolap/RolapMemberBase.java
+++ b/src/main/java/mondrian/rolap/RolapMemberBase.java
@@ -718,6 +718,11 @@ public class RolapMemberBase
                 return resource;
             }
         }
+
+        if (this.getLevel() != null && getLevel().getMemberFormatter() != null) {
+        	return getLevel().getMemberFormatter().formatMember(this);
+        }
+
         return Larders.get(this, getLarder(), prop, locale);
     }
 


### PR DESCRIPTION
In case a member defines a formatter apply it when getting a localized caption.
